### PR TITLE
ツイート一覧画面の修正

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -3,19 +3,19 @@ class TweetsController < ApplicationController
   before_action :move_to_index, except: :index
 
   def index
-    @tweets = Tweet.order("created_at DESC").page(params[:page]).per(5)
+    @tweets = Tweet.includes(:user).page(params[:page]).per(5).order("created_at DESC")
   end
 
   def new
   end
 
   def create
-    Tweet.create(name: tweet_params[:name], image: tweet_params[:image], text: tweet_params[:text], user_id: current_user.id)
+    Tweet.create(image: tweet_params[:image], text: tweet_params[:text], user_id: current_user.id)
   end
 
   private
   def tweet_params
-    params.permit(:name, :image, :text)
+    params.permit(:image, :text)
   end
 
   def move_to_index

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -2,7 +2,10 @@
   <% @tweets.each do |tweet| %>
     <div class="content_post" style="background-image: url(<%= tweet.image %>);">
       <%= simple_format(tweet.text) %>
-      <span class="name"><%= tweet.name %></span>
+      <span class="name">
+        <a href="">
+          <span>投稿者</span><%= tweet.user.nickname %>
+        </a>
     </div>
   <% end %>
   <%= paginate(@tweets)%>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -3,7 +3,6 @@
     <h3>
       投稿する
     </h3>
-    <input placeholder="Nickmane" type="text" name="name">
     <input placeholder="Image Url" type="text" name="image">
     <textarea cols="30" name="text" placeholder="text" rows="10"></textarea>
     <input type="submit" value="SEND">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,6 @@
   <% @tweets.each do |tweet| %>
     <div class="content_post" style="background-image: url(<%= tweet.image %>);">
       <%= simple_format(tweet.text) %>
-      <span class="name"><%= tweet.name %></span>
     </div>
   <% end %>
   <%= paginate(@tweets) %>

--- a/db/migrate/20190929053246_remove_name_from_tweets.rb
+++ b/db/migrate/20190929053246_remove_name_from_tweets.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromTweets < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :tweets, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_074911) do
+ActiveRecord::Schema.define(version: 2019_09_29_053246) do
 
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
     t.text "text"
     t.text "image"
     t.datetime "created_at"


### PR DESCRIPTION
# What
ツイート一覧画面の修正を行う。アソシエーションを利用して、ツイート一覧画面のnameの表示をnicknameに変更する。

# Why
投稿したユーザーのnicknameを自動で反映させる事で、ツイート投稿時にnameを入力する手間を省き、ユーザビリティを向上させる為。